### PR TITLE
Fix off by one error in reading material generation.

### DIFF
--- a/functions/src/contentExtractors/morningBriefingReadingMaterial.ts
+++ b/functions/src/contentExtractors/morningBriefingReadingMaterial.ts
@@ -33,8 +33,9 @@ const findIndexOfLunchTimeReadHeader = (textBlocks: string[]): OptionIndex => {
     }
     i += 1;
   }
-
-  return foundReadingMaterial ? new Index(i) : new OutOfBounds();
+  // i - 1 to account for the +1 from the while loop
+  const indexOfTheLunchTimeRead = new Index(i - 1);
+  return foundReadingMaterial ? indexOfTheLunchTimeRead : new OutOfBounds();
 };
 
 const extractLunchTimeReadURLFromMorningBriefing = (


### PR DESCRIPTION
Previous approach worked fine for articles like [this]( https://www.theguardian.com/world/2019/feb/25/monday-briefing-olivia-colman-crowned-favourite-actress) but failed for articles like [this](https://www.theguardian.com/world/2019/feb/27/wednesday-briefing-trump-is-a-and-a-racist-cohen) where the lunchtime read picture appears before the text body. 

Updating the index so that code starts scanning for the first link starting from the "Lunchtime Read" header.