### PR TITLE
Replace reading material with Trending Article.

### DIFF
--- a/functions/src/contentExtractors/morningBriefingTopStories.ts
+++ b/functions/src/contentExtractors/morningBriefingTopStories.ts
@@ -1,5 +1,9 @@
 import { Article, ContentError, TopStories } from '../models/contentModels';
-import { getTextBlocksFromArticle, stripHTMLTags } from '../utils';
+import {
+  getTextBlocksFromArticle,
+  stripHTMLTags,
+  getFirstSentence,
+} from '../utils';
 
 import { Result } from '../models/capiModels';
 import { load } from 'cheerio';
@@ -77,10 +81,6 @@ const getStoriesFromMorningBriefing = (
     i += 1;
   }
   return stories;
-};
-
-const getFirstSentence = (text: string): string => {
-  return `${text.split('.')[0]}.`;
 };
 
 const convertFirstSentenceToArticle = (

--- a/functions/src/contentExtractors/trendingArticles.ts
+++ b/functions/src/contentExtractors/trendingArticles.ts
@@ -1,0 +1,66 @@
+import { Article, ContentError } from '../models/contentModels';
+
+import { CapiTrending } from '../models/capiModels';
+import fetch from 'node-fetch';
+import { getFirstSentence } from '../utils';
+
+/*
+Current rules for trendingArticles:
+The top story from /UK most viewed according to CAPI
+First sentence of top story
+Story must have the pillarId pillar/news and not be a live blog
+*/
+
+const getTrendingArticle = (
+  capiKey: string
+): Promise<Article | ContentError> => {
+  const trendingArticles = `http://content.guardianapis.com/uk?api-key=${capiKey}&page-size=10&show-most-viewed=true&show-fields=headline,standfirst,body,bodyText`;
+  return fetch(trendingArticles)
+    .then<CapiTrending>(res => {
+      return res.json();
+    })
+    .then(capiResponse => {
+      return processTrendingArticles(capiResponse);
+    })
+    .catch(e => {
+      console.error(`Unable to get Trending Articles. Error: ${e}`);
+      return new ContentError('Could not get Trending Articles');
+    });
+};
+
+const processTrendingArticles = (
+  results: CapiTrending
+): Article | ContentError => {
+  if (results.response.mostViewed.length < 1) {
+    console.error('No matches for Trending Articles query');
+    return new ContentError('No matches found for Trending Articles Query');
+  } else {
+    const articles = results.response.mostViewed;
+    let foundArticle = false;
+    let i = 0;
+    let article = new Article('', '');
+    while (!foundArticle && i < articles.length) {
+      const currentArticle = articles[i];
+      if (
+        currentArticle.type !== 'liveblog' &&
+        currentArticle.pillarId === 'pillar/news'
+      ) {
+        const fields = articles[i].fields;
+        article = new Article(
+          fields.headline,
+          getFirstSentence(fields.bodyText)
+        );
+        foundArticle = true;
+      }
+
+      i++;
+    }
+    if (foundArticle) {
+      return article;
+    } else {
+      return new ContentError('No valid articles in Trending Articles Query');
+    }
+  }
+};
+
+export { getTrendingArticle };

--- a/functions/src/generators/audioFileGeneration.ts
+++ b/functions/src/generators/audioFileGeneration.ts
@@ -78,14 +78,14 @@ const getTextToSpeechBodyRequest = (ssml: string) => {
     audioConfig: {
       audioEncoding: 'OGG_OPUS',
       pitch: '0.00',
-      speakingRate: '1.00',
+      speakingRate: '0.92',
     },
     input: {
       ssml,
     },
     voice: {
       languageCode: 'en-GB',
-      name: 'en-GB-Wavenet-A',
+      name: 'en-GB-Wavenet-B',
     },
   };
 };

--- a/functions/src/generators/nastySSMLGeneration.ts
+++ b/functions/src/generators/nastySSMLGeneration.ts
@@ -7,35 +7,35 @@ Very hacky generation of SSML.
 const generateSSML = (morningBriefing: MorningBriefing) => {
   const topStories = morningBriefing.topStories;
   const todayInFocus = morningBriefing.todayInFocus;
-  const readingMaterial = morningBriefing.readingMaterial;
+  const trendingArticle = morningBriefing.trendingArticle;
   if (
     topStories instanceof TopStories &&
     todayInFocus instanceof Article &&
-    readingMaterial instanceof Article
+    trendingArticle instanceof Article
   ) {
     const topStoriesSSML = generateTopStories(topStories);
     const todayInFocusSSML = generateTodayInFocus(todayInFocus, 'wordsHD3');
-    const readingMaterialSSML = generateReadingMaterial(
-      readingMaterial,
+    const trendingArticleSSML = generateTrendingArticle(
+      trendingArticle,
       'musicTIF'
     );
     const outro = generateOutro('wordslongread');
     return morningBriefingSSML(
       topStoriesSSML,
       todayInFocusSSML,
-      readingMaterialSSML,
+      trendingArticleSSML,
       outro
     );
   }
   // Take into account missing Today in Focus
-  if (topStories instanceof TopStories && readingMaterial instanceof Article) {
+  if (topStories instanceof TopStories && trendingArticle instanceof Article) {
     const topStoriesSSML = generateTopStories(topStories);
-    const readingMaterialSSML = generateReadingMaterial(
-      readingMaterial,
+    const trendingArticleSSML = generateTrendingArticle(
+      trendingArticle,
       'wordsHD3'
     );
     const outro = generateOutro('wordslongread');
-    return morningBriefingSSML(topStoriesSSML, '', readingMaterialSSML, outro);
+    return morningBriefingSSML(topStoriesSSML, '', trendingArticleSSML, outro);
   } else {
     return 'SSML generation failed';
   }
@@ -44,7 +44,7 @@ const generateSSML = (morningBriefing: MorningBriefing) => {
 const morningBriefingSSML = (
   topStoriesSSML: string,
   todayInFocusSSML: string,
-  readingMaterialSSML: string,
+  trendingArticleSSML: string,
   outro: string
 ) => {
   const ssml = `<speak>
@@ -58,7 +58,7 @@ const morningBriefingSSML = (
     
     ${topStoriesSSML}
     ${todayInFocusSSML}
-    ${readingMaterialSSML}
+    ${trendingArticleSSML}
     ${outro}
   </par> 
 </speak>`;
@@ -117,14 +117,13 @@ const generateTodayInFocus = (article: Article, previous: string) => {
   return ssml;
 };
 
-const generateReadingMaterial = (article: Article, previous: string) => {
+const generateTrendingArticle = (article: Article, previous: string) => {
   const ssml = `<media xml:id = 'longread' begin = '${previous}.end-1.6s' soundLevel = '0dB' fadeOutDur = '0.0s' >
-    <audio src='https://storage.googleapis.com/guardian-briefing-audio-assets/Leah_v2_Reading_-3db.ogg' clipBegin = '0.0s'/>
+    <audio src='https://storage.googleapis.com/guardian-briefing-audio-assets/Leah_v2_Trendingv2.ogg' clipBegin = '0.0s'/>
     </media>
 
     <media xml:id = 'wordslongread' begin = 'longread.end+0.0s' soundLevel = '0dB' fadeOutDur = '0.0s' >
       <speak>
-      ${article.headline} <break strength='strong' />
       ${article.standfirst}
       </speak>
     </media>`;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,10 +12,10 @@ import { CapiResults, Result } from './models/capiModels';
 import fetch from 'node-fetch';
 import { generateSSML } from './generators/nastySSMLGeneration';
 import { getDateFromString } from './utils';
-import { getReadingMaterial } from './contentExtractors/morningBriefingReadingMaterial';
 import { getTodayInFocus } from './contentExtractors/todayInFocus';
 import { getTopStories } from './contentExtractors/morningBriefingTopStories';
 import { generateAudioFile } from './generators/audioFileGeneration';
+import { getTrendingArticle } from './contentExtractors/trendingArticles';
 
 const capiKey = config().guardian.capikey;
 const googleTextToSpeechKey = config().googletexttospeech.key;
@@ -44,12 +44,12 @@ const buildTestData = (): Promise<APIResponse[]> => {
 const processResult = (result: Result): Promise<APIResponse> => {
   const articleDate = getDateFromString(result.webPublicationDate);
   return getTodayInFocus(articleDate, capiKey).then(todayInFocus => {
-    return getReadingMaterial(result, capiKey).then(readingMaterial => {
+    return getTrendingArticle(capiKey).then(trendingArticle => {
       return buildResponse(
         articleDate,
         getTopStories(result),
         todayInFocus,
-        readingMaterial
+        trendingArticle
       );
     });
   });
@@ -77,12 +77,12 @@ const buildResponse = (
   articleDate: string,
   topStories: OptionContent,
   todayInFocus: OptionContent,
-  readingMaterial: OptionContent
+  trendingArticle: OptionContent
 ): Promise<APIResponse> => {
   const morningBriefing = buildMorningBriefing(
     topStories,
     todayInFocus,
-    readingMaterial
+    trendingArticle
   );
   const ssml = generateSSML(morningBriefing);
   return generateAudioFile(ssml, googleTextToSpeechKey).then(url => {
@@ -93,7 +93,7 @@ const buildResponse = (
 const buildMorningBriefing = (
   topStories: OptionContent,
   todayInFocus: OptionContent,
-  readingMaterial: OptionContent
+  trendingArticle: OptionContent
 ) => {
   const response = new MorningBriefing();
   if (topStories instanceof TopStories) {
@@ -102,8 +102,8 @@ const buildMorningBriefing = (
   if (todayInFocus instanceof Article) {
     response.todayInFocus = todayInFocus;
   }
-  if (readingMaterial instanceof Article) {
-    response.readingMaterial = readingMaterial;
+  if (trendingArticle instanceof Article) {
+    response.trendingArticle = trendingArticle;
   }
   return response;
 };

--- a/functions/src/models/capiModels.ts
+++ b/functions/src/models/capiModels.ts
@@ -1,3 +1,11 @@
+interface CapiTrending {
+  response: CapiMostViewed;
+}
+
+interface CapiMostViewed {
+  mostViewed: Result[];
+}
+
 interface CapiResult {
   response: CapiResponse;
 }
@@ -15,6 +23,9 @@ interface Results {
 }
 
 interface Result {
+  type: string;
+  sectionId: string;
+  pillarId: string;
   webPublicationDate: string;
   fields: Fields;
   blocks: Blocks;
@@ -24,6 +35,7 @@ interface Fields {
   standfirst: string;
   headline: string;
   body: string;
+  bodyText: string;
 }
 
 interface Blocks {
@@ -43,4 +55,12 @@ interface Data {
   html: string;
 }
 
-export { Result, Element, CapiResults, CapiResult, Data };
+export {
+  Result,
+  Element,
+  CapiResults,
+  CapiResult,
+  Data,
+  CapiMostViewed,
+  CapiTrending,
+};

--- a/functions/src/models/contentModels.ts
+++ b/functions/src/models/contentModels.ts
@@ -43,7 +43,7 @@ class MorningBriefing {
   constructor(
     public topStories?: TopStories,
     public todayInFocus?: Article,
-    public readingMaterial?: Article
+    public trendingArticle?: Article
   ) {}
 }
 

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -67,9 +67,14 @@ const getCapiArticle = (
     });
 };
 
+const getFirstSentence = (text: string): string => {
+  return `${text.split('. ')[0]}.`;
+};
+
 export {
   getDateFromString,
   stripHTMLTags,
   getTextBlocksFromArticle,
   getCapiArticle,
+  getFirstSentence,
 };


### PR DESCRIPTION
Getting the Lunch Time Read from the Morning Briefing was proving unreliable. Switch to getting the top trending story from CAPI in the past 24 hours.

Story must have the pillar id "pillar/news" and cannot be a live blog.