### PR TITLE
Add fix to exclude morning briefing from trending articles list.

### DIFF
--- a/functions/src/__tests__/utils.test.ts
+++ b/functions/src/__tests__/utils.test.ts
@@ -29,10 +29,14 @@ describe('Extract text elements from article', () => {
   test('All non text elements should be removed', () => {
     const input: Result = {
       webPublicationDate: '2019-02-13T06:29:06Z',
+      type: '',
+      pillarId: '',
+      sectionId: '',
       fields: {
         headline: '',
         standfirst: '',
         body: '',
+        bodyText: '',
       },
       blocks: {
         body: [

--- a/functions/src/contentExtractors/__tests__/morningBriefingReadingMaterial.test.ts
+++ b/functions/src/contentExtractors/__tests__/morningBriefingReadingMaterial.test.ts
@@ -35,10 +35,14 @@ describe('Extract reading material URL from the Morning Briefing', () => {
   test('If the lunchtime read header cannot be found return ContentError object', () => {
     const input: Result = {
       webPublicationDate: '',
+      type: '',
+      sectionId: '',
+      pillarId: '',
       fields: {
         headline: '',
         standfirst: '',
         body: '',
+        bodyText: '',
       },
       blocks: {
         body: [
@@ -56,10 +60,14 @@ describe('Extract reading material URL from the Morning Briefing', () => {
   test('If a URL for the lunchtime read cannot be found return a ContentError object', () => {
     const input: Result = {
       webPublicationDate: '',
+      type: '',
+      sectionId: '',
+      pillarId: '',
       fields: {
         headline: '',
         standfirst: '',
         body: '',
+        bodyText: '',
       },
       blocks: {
         body: [
@@ -85,10 +93,14 @@ describe('Extract reading material URL from the Morning Briefing', () => {
   test('If the url of the lunchtime read can be found return a URL object.', () => {
     const input: Result = {
       webPublicationDate: '',
+      type: '',
+      sectionId: '',
+      pillarId: '',
       fields: {
         headline: '',
         standfirst: '',
         body: '',
+        bodyText: '',
       },
       blocks: {
         body: [

--- a/functions/src/contentExtractors/__tests__/todayInFocus.test.ts
+++ b/functions/src/contentExtractors/__tests__/todayInFocus.test.ts
@@ -10,12 +10,16 @@ describe('Process the results of Today in Focus query', () => {
         results: [
           {
             webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: '',
+            type: '',
             fields: {
               headline:
                 "Why are homeless people still dying in one of Britain's richest cities?",
               standfirst:
                 '<p>After a spike in deaths among homeless people in the affluent city of Oxford, Robert Booth went to investigate.In a growing community of rough sleepers, there is little support for people with mental health problems and addiction.Plus: Nosheen Iqbal on the ‘white fragility’ preventing a frank national discussion about racism</p>',
               body: '',
+              bodyText: '',
             },
             blocks: {
               body: [],

--- a/functions/src/contentExtractors/trendingArticles.ts
+++ b/functions/src/contentExtractors/trendingArticles.ts
@@ -43,7 +43,8 @@ const processTrendingArticles = (
       const currentArticle = articles[i];
       if (
         currentArticle.type !== 'liveblog' &&
-        currentArticle.pillarId === 'pillar/news'
+        currentArticle.pillarId === 'pillar/news' &&
+        !currentArticle.fields.headline.toLowerCase().includes('briefing')
       ) {
         const fields = articles[i].fields;
         article = new Article(


### PR DESCRIPTION
The top three stories are being pulled from the Morning Briefing. The Morning Briefing is also an article so can appear in the list populating the 'trending articles' feed. Add a condition to exclude Morning Briefing article based on the headline.

A fast fix not a perfect fix as it breaks the live Action. Ideally we should move towards using the tags to determine if a article is the Morning Briefing.