### PR TITLE
The morning briefing should not be used as the trending article

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Voice Lab Project. This takes the Morning Briefing and extracts structured data 
 
 - Three Top Stories - These are the first three stories in the morning briefing. For each story take the first sentence about it in the morning briefing
 - Today in Focus - For the Today in Focus article for the day get the headline and first 2 sentences of the standfirst
-- Reading Material - The article recommended as Lunchtime Reading. Get the headline and standfirst from the article itself
+- Trending Article - The first article when querying `http://content.guardianapis.com/uk` by most-viewed. The article must have the pillar id 'pillar/news'. The article must not be a live blog or have the morning briefing tag on it.
 
 # Set Up
 

--- a/functions/src/__tests__/utils.test.ts
+++ b/functions/src/__tests__/utils.test.ts
@@ -39,6 +39,7 @@ describe('Extract text elements from article', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {

--- a/functions/src/contentExtractors/__tests__/morningBriefingReadingMaterial.test.ts
+++ b/functions/src/contentExtractors/__tests__/morningBriefingReadingMaterial.test.ts
@@ -45,6 +45,7 @@ describe('Extract reading material URL from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {
@@ -71,6 +72,7 @@ describe('Extract reading material URL from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {
@@ -105,6 +107,7 @@ describe('Extract reading material URL from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {

--- a/functions/src/contentExtractors/__tests__/morningBriefingTopStories.test.ts
+++ b/functions/src/contentExtractors/__tests__/morningBriefingTopStories.test.ts
@@ -7,6 +7,7 @@ describe('Extract top stories from the Morning Briefing', () => {
   test("If the top story in the Morning Briefing can't be extracted return a ContentError object", () => {
     const input: Result = {
       webPublicationDate: '',
+      webUrl: '',
       sectionId: '',
       pillarId: '',
       type: '',
@@ -16,6 +17,7 @@ describe('Extract top stories from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {
@@ -35,6 +37,7 @@ describe('Extract top stories from the Morning Briefing', () => {
   test('If three stories cannot be extracted from the Morning Briefing return a ContentError object', () => {
     const input: Result = {
       webPublicationDate: '',
+      webUrl: '',
       sectionId: '',
       pillarId: '',
       type: '',
@@ -44,6 +47,7 @@ describe('Extract top stories from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {
@@ -66,11 +70,13 @@ describe('Extract top stories from the Morning Briefing', () => {
         headline: '‘Long extension if they don’t vote for deal’.',
         standfirst:
           'Theresa May’s Brexit strategy may have been accidentally revealed after her chief negotiator, Olly Robbins, was overheard in a Brussels bar suggesting that MPs will be given a last-minute choice between voting for her deal or accepting a long extension to article 50.',
+        source: '',
       },
       {
         headline: '‘It was hell’.',
         standfirst:
           'Thursday will mark one year since 17 people were shot and killed at the Marjory Stoneman Douglas high school in Parkland, Florida.',
+        source: '',
       },
     ];
 
@@ -84,6 +90,7 @@ describe('Extract top stories from the Morning Briefing', () => {
   test('If only the top story can be extracted from the Morning Briefing return a ContentError object', () => {
     const input: Result = {
       webPublicationDate: '',
+      webUrl: '',
       sectionId: '',
       pillarId: '',
       type: '',
@@ -93,6 +100,7 @@ describe('Extract top stories from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {
@@ -115,6 +123,7 @@ describe('Extract top stories from the Morning Briefing', () => {
         headline: '‘Long extension if they don’t vote for deal’.',
         standfirst:
           'Theresa May’s Brexit strategy may have been accidentally revealed after her chief negotiator, Olly Robbins, was overheard in a Brussels bar suggesting that MPs will be given a last-minute choice between voting for her deal or accepting a long extension to article 50.',
+        source: '',
       },
     ];
 
@@ -128,6 +137,7 @@ describe('Extract top stories from the Morning Briefing', () => {
   test('Midweek catch-up in Morning Briefing should be ignored', () => {
     const input: Result = {
       webPublicationDate: '',
+      webUrl: '',
       sectionId: '',
       pillarId: '',
       type: '',
@@ -137,6 +147,7 @@ describe('Extract top stories from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {
@@ -163,15 +174,18 @@ describe('Extract top stories from the Morning Briefing', () => {
     const expectedOutput = new TopStories(
       new Article(
         '‘Long extension if they don’t vote for deal’.',
-        'Theresa May’s Brexit strategy may have been accidentally revealed after her chief negotiator, Olly Robbins, was overheard in a Brussels bar suggesting that MPs will be given a last-minute choice between voting for her deal or accepting a long extension to article 50.'
+        'Theresa May’s Brexit strategy may have been accidentally revealed after her chief negotiator, Olly Robbins, was overheard in a Brussels bar suggesting that MPs will be given a last-minute choice between voting for her deal or accepting a long extension to article 50.',
+        ''
       ),
       new Article(
         '‘It was hell’.',
-        'Thursday will mark one year since 17 people were shot and killed at the Marjory Stoneman Douglas high school in Parkland, Florida.'
+        'Thursday will mark one year since 17 people were shot and killed at the Marjory Stoneman Douglas high school in Parkland, Florida.',
+        ''
       ),
       new Article(
         'Trouble for Trudeau.',
-        'A minister in Justin Trudeau’s Canadian government has resigned amid allegations the prime minister’s office pressured her to avoid prosecuting a major engineering firm.'
+        'A minister in Justin Trudeau’s Canadian government has resigned amid allegations the prime minister’s office pressured her to avoid prosecuting a major engineering firm.',
+        ''
       )
     );
     expect(getTopStories(input)).toEqual(expectedOutput);
@@ -180,6 +194,7 @@ describe('Extract top stories from the Morning Briefing', () => {
   test('If stories can be extracted return TopStories object', () => {
     const input: Result = {
       webPublicationDate: '',
+      webUrl: '',
       sectionId: '',
       pillarId: '',
       type: '',
@@ -189,6 +204,7 @@ describe('Extract top stories from the Morning Briefing', () => {
         body: '',
         bodyText: '',
       },
+      tags: [],
       blocks: {
         body: [
           {
@@ -229,15 +245,18 @@ describe('Extract top stories from the Morning Briefing', () => {
     const expectedOutput = new TopStories(
       new Article(
         '‘Long extension if they don’t vote for deal’.',
-        'Theresa May’s Brexit strategy may have been accidentally revealed after her chief negotiator, Olly Robbins, was overheard in a Brussels bar suggesting that MPs will be given a last-minute choice between voting for her deal or accepting a long extension to article 50.'
+        'Theresa May’s Brexit strategy may have been accidentally revealed after her chief negotiator, Olly Robbins, was overheard in a Brussels bar suggesting that MPs will be given a last-minute choice between voting for her deal or accepting a long extension to article 50.',
+        ''
       ),
       new Article(
         '‘It was hell’.',
-        'Thursday will mark one year since 17 people were shot and killed at the Marjory Stoneman Douglas high school in Parkland, Florida.'
+        'Thursday will mark one year since 17 people were shot and killed at the Marjory Stoneman Douglas high school in Parkland, Florida.',
+        ''
       ),
       new Article(
         'Trouble for Trudeau.',
-        'A minister in Justin Trudeau’s Canadian government has resigned amid allegations the prime minister’s office pressured her to avoid prosecuting a major engineering firm.'
+        'A minister in Justin Trudeau’s Canadian government has resigned amid allegations the prime minister’s office pressured her to avoid prosecuting a major engineering firm.',
+        ''
       )
     );
     expect(getTopStories(input)).toEqual(expectedOutput);

--- a/functions/src/contentExtractors/__tests__/todayInFocus.test.ts
+++ b/functions/src/contentExtractors/__tests__/todayInFocus.test.ts
@@ -22,6 +22,7 @@ describe('Process the results of Today in Focus query', () => {
               body: '',
               bodyText: '',
             },
+            tags: [],
             blocks: {
               body: [],
             },

--- a/functions/src/contentExtractors/__tests__/trendingArticles.test.ts
+++ b/functions/src/contentExtractors/__tests__/trendingArticles.test.ts
@@ -1,0 +1,270 @@
+import { CapiTrending } from '../../models/capiModels';
+import { Article } from '../../models/contentModels';
+import {
+  processTrendingArticles,
+  isMorningBriefing,
+} from '../trendingArticles';
+
+describe('processTrendingArticles', () => {
+  test('should transform a CapiTrending object into an Article', () => {
+    const input: CapiTrending = {
+      response: {
+        mostViewed: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const expectedResult = new Article(
+      'First Article',
+      '.',
+      'www.theguardian.com'
+    );
+    expect(processTrendingArticles(input)).toEqual(expectedResult);
+  });
+
+  test('should ignore articles without the news pillar ID', () => {
+    const input: CapiTrending = {
+      response: {
+        mostViewed: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/opinion',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const expectedResult = new Article(
+      'Second Article',
+      '.',
+      'www.theguardian.com'
+    );
+    expect(processTrendingArticles(input)).toEqual(expectedResult);
+  });
+  test('should ignore liveblogs', () => {
+    const input: CapiTrending = {
+      response: {
+        mostViewed: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/opinion',
+            type: 'liveblog',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const expectedResult = new Article(
+      'Second Article',
+      '.',
+      'www.theguardian.com'
+    );
+    expect(processTrendingArticles(input)).toEqual(expectedResult);
+  });
+
+  test('should ignore the morning briefing', () => {
+    const input: CapiTrending = {
+      response: {
+        mostViewed: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/opinion',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [
+              {
+                id: 'world/series/guardian-morning-briefing',
+              },
+            ],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const expectedResult = new Article(
+      'Second Article',
+      '.',
+      'www.theguardian.com'
+    );
+    expect(processTrendingArticles(input)).toEqual(expectedResult);
+  });
+});
+
+describe('isMorningBriefing', () => {
+  test('should return true if Result has a morning briefing tag', () => {
+    const input = {
+      webPublicationDate: '2019-02-11T03:00:06Z',
+      sectionId: '',
+      pillarId: 'pillar/opinion',
+      type: '',
+      webUrl: 'www.theguardian.com',
+      fields: {
+        headline: 'First Article',
+        standfirst: '',
+        body: '',
+        bodyText: '',
+      },
+      tags: [
+        {
+          id: 'world/series/guardian-morning-briefing',
+        },
+        {
+          id: 'other tag',
+        },
+      ],
+      blocks: {
+        body: [],
+      },
+    };
+    expect(isMorningBriefing(input)).toEqual(true);
+  });
+
+  test('should return false if Result has no morning briefing tag', () => {
+    const input = {
+      webPublicationDate: '2019-02-11T03:00:06Z',
+      sectionId: '',
+      pillarId: 'pillar/opinion',
+      type: '',
+      webUrl: 'www.theguardian.com',
+      fields: {
+        headline: 'First Article',
+        standfirst: '',
+        body: '',
+        bodyText: '',
+      },
+      tags: [
+        {
+          id: 'other tag',
+        },
+      ],
+      blocks: {
+        body: [],
+      },
+    };
+    expect(isMorningBriefing(input)).toEqual(false);
+  });
+
+  test('should return false if Result has no tags', () => {
+    const input = {
+      webPublicationDate: '2019-02-11T03:00:06Z',
+      sectionId: '',
+      pillarId: 'pillar/opinion',
+      type: '',
+      webUrl: 'www.theguardian.com',
+      fields: {
+        headline: 'First Article',
+        standfirst: '',
+        body: '',
+        bodyText: '',
+      },
+      tags: [],
+      blocks: {
+        body: [],
+      },
+    };
+    expect(isMorningBriefing(input)).toEqual(false);
+  });
+});

--- a/functions/src/models/capiModels.ts
+++ b/functions/src/models/capiModels.ts
@@ -30,6 +30,7 @@ interface Result {
   webUrl: string;
   fields: Fields;
   blocks: Blocks;
+  tags: Tag[];
 }
 
 interface Fields {
@@ -37,6 +38,10 @@ interface Fields {
   headline: string;
   body: string;
   bodyText: string;
+}
+
+interface Tag {
+  id: string;
 }
 
 interface Blocks {


### PR DESCRIPTION
The briefing is based on the UK Morning Briefing article. If this article is also in the trending stories list then it should not be used. Checking the tags on the candidates for the trending stories slot to make sure that the morning briefing is not included