### PR TITLE
Ignore articles that do not have body text 

### DIFF
--- a/functions/src/contentExtractors/__tests__/trendingArticle.test.ts
+++ b/functions/src/contentExtractors/__tests__/trendingArticle.test.ts
@@ -17,7 +17,7 @@ describe('processTrendingArticles', () => {
               headline: 'First Article',
               standfirst: '',
               body: '',
-              bodyText: '',
+              bodyText: 'Article',
             },
             tags: [],
             blocks: {
@@ -30,7 +30,7 @@ describe('processTrendingArticles', () => {
 
     const expectedResult = new Article(
       'First Article',
-      '.',
+      'Article.',
       'www.theguardian.com'
     );
     expect(processTrendingArticles(input)).toEqual(expectedResult);
@@ -50,7 +50,7 @@ describe('processTrendingArticles', () => {
               headline: 'First Article',
               standfirst: '',
               body: '',
-              bodyText: '',
+              bodyText: 'Article',
             },
             tags: [],
             blocks: {
@@ -67,7 +67,7 @@ describe('processTrendingArticles', () => {
               headline: 'Second Article',
               standfirst: '',
               body: '',
-              bodyText: '',
+              bodyText: 'Article',
             },
             tags: [],
             blocks: {
@@ -80,7 +80,7 @@ describe('processTrendingArticles', () => {
 
     const expectedResult = new Article(
       'Second Article',
-      '.',
+      'Article.',
       'www.theguardian.com'
     );
     expect(processTrendingArticles(input)).toEqual(expectedResult);
@@ -99,7 +99,7 @@ describe('processTrendingArticles', () => {
               headline: 'First Article',
               standfirst: '',
               body: '',
-              bodyText: '',
+              bodyText: 'Article',
             },
             tags: [],
             blocks: {
@@ -116,7 +116,7 @@ describe('processTrendingArticles', () => {
               headline: 'Second Article',
               standfirst: '',
               body: '',
-              bodyText: '',
+              bodyText: 'Article',
             },
             tags: [],
             blocks: {
@@ -129,7 +129,7 @@ describe('processTrendingArticles', () => {
 
     const expectedResult = new Article(
       'Second Article',
-      '.',
+      'Article.',
       'www.theguardian.com'
     );
     expect(processTrendingArticles(input)).toEqual(expectedResult);
@@ -149,7 +149,7 @@ describe('processTrendingArticles', () => {
               headline: 'First Article',
               standfirst: '',
               body: '',
-              bodyText: '',
+              bodyText: 'Article',
             },
             tags: [
               {
@@ -170,7 +170,7 @@ describe('processTrendingArticles', () => {
               headline: 'Second Article',
               standfirst: '',
               body: '',
-              bodyText: '',
+              bodyText: 'Article',
             },
             tags: [],
             blocks: {
@@ -183,7 +183,57 @@ describe('processTrendingArticles', () => {
 
     const expectedResult = new Article(
       'Second Article',
-      '.',
+      'Article.',
+      'www.theguardian.com'
+    );
+    expect(processTrendingArticles(input)).toEqual(expectedResult);
+  });
+
+  test('should ignore articles with no bodyText', () => {
+    const input: CapiTrending = {
+      response: {
+        mostViewed: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/opinion',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const expectedResult = new Article(
+      'Second Article',
+      'Article.',
       'www.theguardian.com'
     );
     expect(processTrendingArticles(input)).toEqual(expectedResult);

--- a/functions/src/contentExtractors/__tests__/ukTopStories.test.ts
+++ b/functions/src/contentExtractors/__tests__/ukTopStories.test.ts
@@ -1,0 +1,525 @@
+import { CapiEditorsPicks } from '../../models/capiModels';
+import { Article, FallbackTopStories } from '../../models/contentModels';
+import { processUKTopStories } from '../ukTopStories';
+
+describe('processUKTopStories', () => {
+  test('should transform a CapiEditorsPicks object into a FallbackTopStories', () => {
+    const input: CapiEditorsPicks = {
+      response: {
+        editorsPicks: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+    const article = new Article(
+      'First Article',
+      'Article.',
+      'www.theguardian.com'
+    );
+    const expectedResult = new FallbackTopStories(
+      article,
+      article,
+      article,
+      article
+    );
+    expect(processUKTopStories(input)).toEqual(expectedResult);
+  });
+
+  test('should ignore articles without the news pillar ID', () => {
+    const input: CapiEditorsPicks = {
+      response: {
+        editorsPicks: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/opinion',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const article = new Article(
+      'Second Article',
+      'Article.',
+      'www.theguardian.com'
+    );
+    const expectedResult = new FallbackTopStories(
+      article,
+      article,
+      article,
+      article
+    );
+    expect(processUKTopStories(input)).toEqual(expectedResult);
+  });
+  test('should ignore liveblogs', () => {
+    const input: CapiEditorsPicks = {
+      response: {
+        editorsPicks: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: 'liveblog',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const article = new Article(
+      'Second Article',
+      'Article.',
+      'www.theguardian.com'
+    );
+    const expectedResult = new FallbackTopStories(
+      article,
+      article,
+      article,
+      article
+    );
+    expect(processUKTopStories(input)).toEqual(expectedResult);
+  });
+
+  test('should ignore the morning briefing', () => {
+    const input: CapiEditorsPicks = {
+      response: {
+        editorsPicks: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [
+              {
+                id: 'world/series/guardian-morning-briefing',
+              },
+            ],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const article = new Article(
+      'Second Article',
+      'Article.',
+      'www.theguardian.com'
+    );
+    const expectedResult = new FallbackTopStories(
+      article,
+      article,
+      article,
+      article
+    );
+    expect(processUKTopStories(input)).toEqual(expectedResult);
+  });
+
+  test('should ignore articles with no bodyText', () => {
+    const input: CapiEditorsPicks = {
+      response: {
+        editorsPicks: [
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'First Article',
+              standfirst: '',
+              body: '',
+              bodyText: '',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+          {
+            webPublicationDate: '2019-02-11T03:00:06Z',
+            sectionId: '',
+            pillarId: 'pillar/news',
+            type: '',
+            webUrl: 'www.theguardian.com',
+            fields: {
+              headline: 'Second Article',
+              standfirst: '',
+              body: '',
+              bodyText: 'Article',
+            },
+            tags: [],
+            blocks: {
+              body: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const article = new Article(
+      'Second Article',
+      'Article.',
+      'www.theguardian.com'
+    );
+    const expectedResult = new FallbackTopStories(
+      article,
+      article,
+      article,
+      article
+    );
+    expect(processUKTopStories(input)).toEqual(expectedResult);
+  });
+});

--- a/functions/src/contentExtractors/extractorUtils.ts
+++ b/functions/src/contentExtractors/extractorUtils.ts
@@ -73,10 +73,15 @@ const isMorningBriefing = (result: Result) => {
   );
 };
 
+const hasBodyText = (result: Result): boolean => {
+  return result.fields.bodyText.length > 0;
+};
+
 export {
   stripHTMLTags,
   getTextBlocksFromArticle,
   getCapiArticle,
   getFirstSentence,
   isMorningBriefing,
+  hasBodyText,
 };

--- a/functions/src/contentExtractors/trendingArticle.ts
+++ b/functions/src/contentExtractors/trendingArticle.ts
@@ -2,7 +2,11 @@ import { Article, ContentError } from '../models/contentModels';
 
 import { CapiTrending } from '../models/capiModels';
 import fetch from 'node-fetch';
-import { getFirstSentence, isMorningBriefing } from './extractorUtils';
+import {
+  getFirstSentence,
+  isMorningBriefing,
+  hasBodyText,
+} from './extractorUtils';
 
 /*
 Current rules for trendingArticles:
@@ -44,7 +48,8 @@ const processTrendingArticles = (
       if (
         currentArticle.type !== 'liveblog' &&
         currentArticle.pillarId === 'pillar/news' &&
-        !isMorningBriefing(currentArticle)
+        !isMorningBriefing(currentArticle) &&
+        hasBodyText(currentArticle)
       ) {
         const fields = articles[i].fields;
         article = new Article(

--- a/functions/src/contentExtractors/ukTopStories.ts
+++ b/functions/src/contentExtractors/ukTopStories.ts
@@ -6,7 +6,11 @@ import {
   OptionContent,
 } from '../models/contentModels';
 import fetch from 'node-fetch';
-import { isMorningBriefing, getFirstSentence } from './extractorUtils';
+import {
+  isMorningBriefing,
+  getFirstSentence,
+  hasBodyText,
+} from './extractorUtils';
 
 /*
 Current rules for uk Top Stories:
@@ -41,7 +45,8 @@ const processUKTopStories = (capiResponse: CapiEditorsPicks): OptionContent => {
     if (
       article.type !== 'liveblog' &&
       article.pillarId === 'pillar/news' &&
-      !isMorningBriefing(article)
+      !isMorningBriefing(article) &&
+      hasBodyText(article)
     ) {
       topStories.push(
         new Article(
@@ -65,4 +70,4 @@ const processUKTopStories = (capiResponse: CapiEditorsPicks): OptionContent => {
   }
 };
 
-export { getUkTopStories };
+export { getUkTopStories, processUKTopStories };


### PR DESCRIPTION
For trending articles and uk top stories the 'standfirst' used is the opening sentence of the article. Some articles like [this one](https://www.theguardian.com/politics/ng-interactive/2019/mar/12/how-did-your-mp-vote-in-the-march-brexit-votes) have no body text. They should not be used when getting content.