### PR TITLE
Timestamp filenames to try and prevent google from caching stale files.

### DIFF
--- a/functions/src/generators/audioFileGeneration.ts
+++ b/functions/src/generators/audioFileGeneration.ts
@@ -2,17 +2,14 @@ import * as fs from 'fs-extra';
 import fetch from 'node-fetch';
 import { GoogleTextToSpeechResponse } from '../models/googleModels';
 import { Storage } from '@google-cloud/storage';
+import * as moment from 'moment';
 
 const googleCloudStorage = new Storage();
 const bucketName = 'gu-briefing-audio';
-const defaultFilename = 'briefing.ogg';
 const writeDirectory = `/tmp/`;
 
-const generateAudioFile = (
-  ssml: string,
-  apiKey: string,
-  filename: string = defaultFilename
-): Promise<string> => {
+const generateAudioFile = (ssml: string, apiKey: string): Promise<string> => {
+  const filename = timestampFilename();
   return fetch(getGoogleTextToSpeechUrl(apiKey), {
     headers: { 'Content-Type': 'application/json' },
     method: 'POST',
@@ -71,6 +68,13 @@ const getAudioAssetUrl = (filename: string) => {
 
 const getGoogleTextToSpeechUrl = (apiKey: string) => {
   return `https://texttospeech.googleapis.com/v1/text:synthesize?key=${apiKey}`;
+};
+
+const timestampFilename = (): string => {
+  const currentUnixTime = moment()
+    .utc()
+    .unix();
+  return `briefing${currentUnixTime}.ogg`;
 };
 
 const getTextToSpeechBodyRequest = (ssml: string) => {


### PR DESCRIPTION
Since rolling out more templates there has been a pretty bad caching problem. This is especially jarring when there is breaking news. The file is served correctly so I think the caching is happening at an Assistant level. Timestamping the briefing audio files to try and get around the caching.