### PR TITLE
Only stories of type article should be included in briefings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Voice Lab Project. This takes the Morning Briefing and extracts structured data 
 
 - Three Top Stories - These are the first three stories in the morning briefing. For each story take the first sentence about it in the morning briefing
 - Today in Focus - For the Today in Focus article for the day get the headline and first 2 sentences of the standfirst
-- Trending Article - The first article when querying `http://content.guardianapis.com/uk` by most-viewed. The article must have the pillar id 'pillar/news'. The article must not be a live blog or have the morning briefing tag on it.
+- Trending Article - The first article when querying `http://content.guardianapis.com/uk` by most-viewed. The article must have the pillar id 'pillar/news'. The article must of of type 'article' and not have the morning briefing tag on it.
 
 ### Fallback
 
@@ -16,7 +16,7 @@ For when none of the other conditions are true or the generation fails
 
 - Three Top Stories - These are from the UK editor's picks. Sourced from CAPI. The articles must have the pillar id 'pillar/news'. The article must not be a live blog or have the morning briefing tag on it.
 - Trending Article - The first article when querying `http://content.guardianapis.com/uk` by most-viewed. The article must have the pillar id 'pillar/news'. The article must not be a live blog or have the morning briefing tag on it.
-- Forth Top Story - Forth story from the UK editor's picks. Sourced from CAPI. The article must have the pillar id 'pillar/news'. The article must not be a live blog or have the morning briefing tag on it.
+- Forth Top Story - Forth story from the UK editor's picks. Sourced from CAPI. The article must have the pillar id 'pillar/news'. he article must of of type 'article' and not have the morning briefing tag on it.
 
 # Set Up
 

--- a/functions/src/contentExtractors/__tests__/trendingArticle.test.ts
+++ b/functions/src/contentExtractors/__tests__/trendingArticle.test.ts
@@ -11,7 +11,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -45,7 +45,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/opinion',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -63,7 +63,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -114,7 +114,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -148,7 +148,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/opinion',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -170,7 +170,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -204,7 +204,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/opinion',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -222,7 +222,7 @@ describe('processTrendingArticles', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',

--- a/functions/src/contentExtractors/__tests__/ukTopStories.test.ts
+++ b/functions/src/contentExtractors/__tests__/ukTopStories.test.ts
@@ -11,7 +11,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -29,7 +29,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -47,7 +47,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -65,7 +65,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -104,7 +104,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/opinion',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -122,7 +122,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -140,7 +140,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -158,7 +158,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -176,7 +176,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -233,7 +233,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -251,7 +251,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -269,7 +269,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -287,7 +287,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -327,7 +327,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -349,7 +349,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -367,7 +367,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -385,7 +385,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -403,7 +403,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -443,7 +443,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'First Article',
@@ -461,7 +461,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -479,7 +479,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -497,7 +497,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',
@@ -515,7 +515,7 @@ describe('processUKTopStories', () => {
             webPublicationDate: '2019-02-11T03:00:06Z',
             sectionId: '',
             pillarId: 'pillar/news',
-            type: '',
+            type: 'article',
             webUrl: 'www.theguardian.com',
             fields: {
               headline: 'Second Article',

--- a/functions/src/contentExtractors/trendingArticle.ts
+++ b/functions/src/contentExtractors/trendingArticle.ts
@@ -12,7 +12,7 @@ import {
 Current rules for trendingArticles:
 The top story from /UK most viewed according to CAPI
 First sentence of top story
-Story must have the pillarId pillar/news and not be a live blog or have the morning briefing tag.
+Story must have the pillarId pillar/news and have the article type 'article' or have the morning briefing tag.
 */
 
 const getTrendingArticle = (
@@ -46,7 +46,7 @@ const processTrendingArticles = (
     while (!foundArticle && i < articles.length) {
       const currentArticle = articles[i];
       if (
-        currentArticle.type !== 'liveblog' &&
+        currentArticle.type === 'article' &&
         currentArticle.pillarId === 'pillar/news' &&
         !isMorningBriefing(currentArticle) &&
         hasBodyText(currentArticle)

--- a/functions/src/contentExtractors/ukTopStories.ts
+++ b/functions/src/contentExtractors/ukTopStories.ts
@@ -16,7 +16,7 @@ import {
 Current rules for uk Top Stories:
 Top stories from CAPI based on showing only editors picks
 First sentence each story
-Story must have the pillarId pillar/news and not be a live blog or have the morning briefing tag.
+Story must have the pillarId pillar/news and have the article type 'article' or have the morning briefing tag.
 */
 
 const numberOfStoriesNeeded = 4;
@@ -43,7 +43,7 @@ const processUKTopStories = (capiResponse: CapiEditorsPicks): OptionContent => {
   while (i < articles.length && topStories.length < numberOfStoriesNeeded) {
     const article = articles[i];
     if (
-      article.type !== 'liveblog' &&
+      article.type === 'article' &&
       article.pillarId === 'pillar/news' &&
       !isMorningBriefing(article) &&
       hasBodyText(article)


### PR DESCRIPTION
Articles in the Guardian Content API can have multiple types e.g. liveblog, video, interactive. These typically don't translate well into Guardian Briefing responses so are being excluded as suggestions