### PR TITLE
Update briefing change over times.

### DIFF
--- a/functions/src/__tests__/briefingSlotCheckers.test.ts
+++ b/functions/src/__tests__/briefingSlotCheckers.test.ts
@@ -70,37 +70,78 @@ describe('isWeekdayAM', () => {
 });
 
 describe('isSaturday', () => {
-  test('should return true on Saturday', () => {
-    const time = moment().day('saturday');
+  test('should return true on Saturday from 6am', () => {
+    const time = moment()
+      .day('saturday')
+      .hour(6);
 
     expect(isSaturday(time)).toEqual(true);
+  });
+  test('should return false on Saturday before 6am', () => {
+    const time = moment()
+      .day('saturday')
+      .hour(5)
+      .minute(59);
+
+    expect(isSaturday(time)).toEqual(false);
   });
   test('should return false on Friday', () => {
     const time = moment().day('friday');
 
     expect(isSaturday(time)).toEqual(false);
   });
-  test('should return false on Sunday', () => {
-    const time = moment().day('sunday');
+  test('should return true on Sunday before 6am', () => {
+    const time = moment()
+      .day('sunday')
+      .hour(5)
+      .minute(59);
+
+    expect(isSaturday(time)).toEqual(true);
+  });
+  test('should return false on Sunday after 5:59am', () => {
+    const time = moment()
+      .day('sunday')
+      .hour(6);
 
     expect(isSaturday(time)).toEqual(false);
   });
 });
 
 describe('isSunday', () => {
-  test('should return true on Sunday', () => {
-    const time = moment().day('sunday');
+  test('should return true on Sunday from 6am', () => {
+    const time = moment()
+      .day('sunday')
+      .hour(6);
 
     expect(isSunday(time)).toEqual(true);
   });
+  test('should return false on Sunday before 6am', () => {
+    const time = moment()
+      .day('sunday')
+      .hour(5)
+      .minute(59);
+
+    expect(isSunday(time)).toEqual(false);
+  });
+
   test('should return false on Saturday', () => {
     const time = moment().day('saturday');
 
     expect(isSunday(time)).toEqual(false);
   });
-  test('should return false on Monday', () => {
-    const time = moment().day('monday');
+  test('should return false on Monday after 5:59am', () => {
+    const time = moment()
+      .day('monday')
+      .hour(6);
 
     expect(isSunday(time)).toEqual(false);
+  });
+  test('should return true on Monday before 6am', () => {
+    const time = moment()
+      .day('monday')
+      .hour(5)
+      .minute(59);
+
+    expect(isSunday(time)).toEqual(true);
   });
 });

--- a/functions/src/briefingSlotCheckers.ts
+++ b/functions/src/briefingSlotCheckers.ts
@@ -13,14 +13,23 @@ const isWeekdayAM = (time: moment.Moment): boolean => {
   return isWeekday && isAfter630AM && !isAfter1030AM;
 };
 
+// We define Saturday as 6am on Saturday to 5:59am on Sunday
 const isSaturday = (time: moment.Moment): boolean => {
+  const hour = time.hour();
+  const minute = time.minute();
   const dayOfWeek = time.day();
-  return dayOfWeek === 6;
+  const validSaturday = dayOfWeek === 6 && hour >= 6;
+  const validSunday = dayOfWeek === 0 && hour <= 5 && minute <= 59;
+  return validSaturday || validSunday;
 };
-
+// We define Sunday as 6am on Sunday to 5:59am on Monday
 const isSunday = (time: moment.Moment): boolean => {
+  const hour = time.hour();
+  const minute = time.minute();
   const dayOfWeek = time.day();
-  return dayOfWeek === 0;
+  const validSunday = dayOfWeek === 0 && hour >= 6;
+  const validMonday = dayOfWeek === 1 && hour <= 5 && minute <= 59;
+  return validSunday || validMonday;
 };
 
 export { isWeekdayAM, isSaturday, isSunday };


### PR DESCRIPTION
Previously the API served the Saturday Briefing all day Saturday and the Sunday Briefing all day Sunday. Tweaked this so that the Saturday Briefing is now served 6am Saturday to 5:59am Sunday and the Sunday Briefing is served 6am Sunday to 5:59am Monday. This is to account for night owls.