### PR TITLE
Exlude content with the analysis tone tag on it.

### DIFF
--- a/functions/src/contentExtractors/__tests__/resultValidator.test.ts
+++ b/functions/src/contentExtractors/__tests__/resultValidator.test.ts
@@ -2,6 +2,7 @@ import {
   isMorningBriefing,
   isValidResult,
   hasGuardianReadersProfile,
+  hasToneTagAnalysis,
 } from '../resultValidator';
 
 describe('isValidResult', () => {
@@ -15,8 +16,8 @@ describe('isValidResult', () => {
       fields: {
         headline: 'First Article',
         standfirst: '',
-        body: 'body',
-        bodyText: '',
+        body: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
@@ -29,7 +30,7 @@ describe('isValidResult', () => {
         body: [],
       },
     };
-    expect(isValidResult(input)).toEqual(false);
+    expect(isValidResult(input)).toEqual(true);
   });
   test('should return false if result is not of type article', () => {
     const input = {
@@ -41,8 +42,8 @@ describe('isValidResult', () => {
       fields: {
         headline: 'First Article',
         standfirst: '',
-        body: 'body',
-        bodyText: '',
+        body: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
@@ -119,14 +120,45 @@ describe('isValidResult', () => {
       fields: {
         headline: 'First Article',
         standfirst: '',
-        body: 'body',
-        bodyText: '',
+        body: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
         {
           id: 'world/series/guardian-morning-briefing',
           type: 'series',
+        },
+        {
+          id: 'tag',
+          type: 'keyword',
+        },
+      ],
+      blocks: {
+        body: [],
+      },
+    };
+    expect(isValidResult(input)).toEqual(false);
+  });
+
+  test('should return false if result has the analysis tone tag on it', () => {
+    const input = {
+      webPublicationDate: '2019-02-11T03:00:06Z',
+      sectionId: '',
+      pillarId: 'pillar/news',
+      type: 'article',
+      webUrl: 'www.theguardian.com',
+      fields: {
+        headline: 'First Article',
+        standfirst: '',
+        body: '',
+        bodyText: 'text',
+        trailText: '',
+      },
+      tags: [
+        {
+          id: 'tone/analysis',
+          type: 'tone',
         },
         {
           id: 'tag',
@@ -153,7 +185,7 @@ describe('isMorningBriefing', () => {
         headline: 'First Article',
         standfirst: '',
         body: '',
-        bodyText: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
@@ -184,7 +216,7 @@ describe('isMorningBriefing', () => {
         headline: 'First Article',
         standfirst: '',
         body: '',
-        bodyText: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
@@ -211,7 +243,7 @@ describe('isMorningBriefing', () => {
         headline: 'First Article',
         standfirst: '',
         body: '',
-        bodyText: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [],
@@ -235,7 +267,7 @@ describe('hasGuardianReaderProfile', () => {
         headline: 'First Article',
         standfirst: '',
         body: '',
-        bodyText: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
@@ -267,7 +299,7 @@ describe('hasGuardianReaderProfile', () => {
         headline: 'First Article',
         standfirst: '',
         body: '',
-        bodyText: '',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
@@ -294,8 +326,8 @@ describe('hasGuardianReaderProfile', () => {
       fields: {
         headline: 'First Article',
         standfirst: '',
-        body: '',
-        bodyText: '',
+        body: 'body',
+        bodyText: 'text',
         trailText: '',
       },
       tags: [
@@ -310,5 +342,95 @@ describe('hasGuardianReaderProfile', () => {
     };
 
     expect(hasGuardianReadersProfile(input)).toEqual(false);
+  });
+});
+
+describe('hasToneTagAnalysis', () => {
+  test('should return true on content which has an analysis tag on it', () => {
+    const input = {
+      webPublicationDate: '2019-02-11T03:00:06Z',
+      sectionId: '',
+      pillarId: 'pillar/opinion',
+      type: '',
+      webUrl: 'www.theguardian.com',
+      fields: {
+        headline: 'First Article',
+        standfirst: '',
+        body: 'body',
+        bodyText: 'text',
+        trailText: '',
+      },
+      tags: [
+        {
+          id: 'tone/analysis',
+          type: 'tone',
+        },
+        {
+          id: 'other tag',
+          type: 'keyword',
+        },
+      ],
+      blocks: {
+        body: [],
+      },
+    };
+
+    expect(hasToneTagAnalysis(input)).toEqual(true);
+  });
+
+  test('should return false on content which does not have an analysis tag on it', () => {
+    const input = {
+      webPublicationDate: '2019-02-11T03:00:06Z',
+      sectionId: '',
+      pillarId: 'pillar/opinion',
+      type: '',
+      webUrl: 'www.theguardian.com',
+      fields: {
+        headline: 'First Article',
+        standfirst: '',
+        body: '',
+        bodyText: 'text',
+        trailText: '',
+      },
+      tags: [
+        {
+          id: 'other tag',
+          type: 'keyword',
+        },
+      ],
+      blocks: {
+        body: [],
+      },
+    };
+
+    expect(hasToneTagAnalysis(input)).toEqual(false);
+  });
+
+  test('should return false on content which does not have an analysis tag on it and has a tag of type "tone" on it', () => {
+    const input = {
+      webPublicationDate: '2019-02-11T03:00:06Z',
+      sectionId: '',
+      pillarId: 'pillar/opinion',
+      type: '',
+      webUrl: 'www.theguardian.com',
+      fields: {
+        headline: 'First Article',
+        standfirst: '',
+        body: '',
+        bodyText: 'text',
+        trailText: '',
+      },
+      tags: [
+        {
+          id: 'other tag',
+          type: 'tone',
+        },
+      ],
+      blocks: {
+        body: [],
+      },
+    };
+
+    expect(hasToneTagAnalysis(input)).toEqual(false);
   });
 });

--- a/functions/src/contentExtractors/resultValidator.ts
+++ b/functions/src/contentExtractors/resultValidator.ts
@@ -7,6 +7,7 @@ import { Result } from '../models/capiModels';
 A result must not have
 - the morning briefing tag.
 - the Guardian Readers contributor tag on it.
+- the analysis tone tag on it.
  */
 const isValidResult = (result: Result): boolean => {
   return (
@@ -14,7 +15,8 @@ const isValidResult = (result: Result): boolean => {
     result.pillarId === 'pillar/news' &&
     hasBodyText(result) &&
     !isMorningBriefing(result) &&
-    !hasGuardianReadersProfile(result)
+    !hasGuardianReadersProfile(result) &&
+    !hasToneTagAnalysis(result)
   );
 };
 
@@ -34,8 +36,20 @@ const hasGuardianReadersProfile = (result: Result) => {
   return guardianReaderProfile.length > 0;
 };
 
+const hasToneTagAnalysis = (result: Result): boolean => {
+  return (
+    result.tags.filter(tag => tag.id === 'tone/analysis' && tag.type === 'tone')
+      .length > 0
+  );
+};
+
 const hasBodyText = (result: Result): boolean => {
   return result.fields.bodyText.length > 0;
 };
 
-export { isValidResult, isMorningBriefing, hasGuardianReadersProfile };
+export {
+  isValidResult,
+  isMorningBriefing,
+  hasGuardianReadersProfile,
+  hasToneTagAnalysis,
+};

--- a/functions/src/contentExtractors/trendingArticle.ts
+++ b/functions/src/contentExtractors/trendingArticle.ts
@@ -15,7 +15,7 @@ Uses resultValidator to check if an article should be included in the top storie
 const getTrendingArticle = (
   capiKey: string
 ): Promise<Article | ContentError> => {
-  const trendingArticles = `http://content.guardianapis.com/uk?api-key=${capiKey}&page-size=10&show-most-viewed=true&show-fields=headline,standfirst,body,bodyText&show-tags=series,contributor`;
+  const trendingArticles = `http://content.guardianapis.com/uk?api-key=${capiKey}&page-size=10&show-most-viewed=true&show-fields=headline,standfirst,body,bodyText&show-tags=all`;
   return fetch(trendingArticles)
     .then<CapiTrending>(res => {
       return res.json();

--- a/functions/src/contentExtractors/ukTopStories.ts
+++ b/functions/src/contentExtractors/ukTopStories.ts
@@ -19,7 +19,7 @@ Uses resultValidator to check if an article should be included in the top storie
 const numberOfStoriesNeeded = 4;
 
 const getUkTopStories = (capiKey: string): Promise<OptionContent> => {
-  const topStories = `http://content.guardianapis.com/uk?api-key=${capiKey}&page-size=10&show-editors-picks=true&only-editors-picks=true&show-most-viewed=false&edition=uk&show-fields=headline,standfirst,body,bodyText&show-tags=series,contributor`;
+  const topStories = `http://content.guardianapis.com/uk?api-key=${capiKey}&page-size=10&show-editors-picks=true&only-editors-picks=true&show-most-viewed=false&edition=uk&show-fields=headline,standfirst,body,bodyText&show-tags=all`;
   return fetch(topStories)
     .then<CapiEditorsPicks>(res => {
       return res.json();


### PR DESCRIPTION
Articles with the tone tag of [analysis](https://www.theguardian.com/tone/analysis) for example [this one](https://www.theguardian.com/politics/2019/mar/20/pathetic-incoherent-chaotic-europes-verdict-on-brexit-shambles) do not work well inside the Guardian Briefing templates when getting top stories or trending articles. Excluding all articles with the tone tag analysis as part of the `isValidResult` functionality. 