### PR TITLE
Get four stories from the Morning Briefing and drop trending article.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Voice Lab Project. This takes the Morning Briefing and extracts structured data 
 
 ### If it's between 6:30am and 10:30am on a week day
 
-- Three Top Stories - These are the first three stories in the morning briefing. For each story take the first sentence about it in the morning briefing
+- Three Top Stories - These are the first three stories in the morning briefing. For each story take the first sentence about it in the [morning briefing](https://www.theguardian.com/world/series/guardian-morning-briefing)
 - Today in Focus - For the Today in Focus article for the day get the headline and first 2 sentences of the standfirst
-- Trending Article - The first article when querying `http://content.guardianapis.com/uk` by most-viewed. The article must have the pillar id 'pillar/news'. The article must of of type 'article' and not have the morning briefing tag on it.
+- Forth Top Story - Forth story in the [Morning Briefing](https://www.theguardian.com/world/series/guardian-morning-briefing).
 
 ### Fallback
 
@@ -38,7 +38,7 @@ The app also requires a service account ID.
 1. Go to the Google Cloud Console for the project
 2. Go to IAM & Admin
 3. Go to Service Accounts
-4. Select the file-upload account and select 'create key'. This will download a key onto your machine.
+4. Select the account called `UploadBriefing` and select 'create key'. This will download a key onto your machine.
 5. In terminal type `export GOOGLE_APPLICATION_CREDENTIALS=path_to_json_file_containing_key`
 
 ## Run locally

--- a/functions/src/contentExtractors/__tests__/morningBriefingTopStories.test.ts
+++ b/functions/src/contentExtractors/__tests__/morningBriefingTopStories.test.ts
@@ -35,7 +35,7 @@ describe('Extract top stories from the Morning Briefing', () => {
     expect(getTopStoriesFromMorningBriefing(input)).toEqual(expectedOutput);
   });
 
-  test('If three stories cannot be extracted from the Morning Briefing return a ContentError object', () => {
+  test('If four stories cannot be extracted from the Morning Briefing return a ContentError object', () => {
     const input: Result = {
       webPublicationDate: '',
       webUrl: '',
@@ -193,6 +193,11 @@ describe('Extract top stories from the Morning Briefing', () => {
         'Trouble for Trudeau.',
         'A minister in Justin Trudeau’s Canadian government has resigned amid allegations the prime minister’s office pressured her to avoid prosecuting a major engineering firm.',
         ''
+      ),
+      new Article(
+        'Frackers knocked back.',
+        'The shale gas firm Cuadrilla has lost its bid for approval to frack at a second site in Lancashire.',
+        ''
       )
     );
     expect(getTopStoriesFromMorningBriefing(input)).toEqual(expectedOutput);
@@ -264,6 +269,11 @@ describe('Extract top stories from the Morning Briefing', () => {
       new Article(
         'Trouble for Trudeau.',
         'A minister in Justin Trudeau’s Canadian government has resigned amid allegations the prime minister’s office pressured her to avoid prosecuting a major engineering firm.',
+        ''
+      ),
+      new Article(
+        'Frackers knocked back.',
+        'The shale gas firm Cuadrilla has lost its bid for approval to frack at a second site in Lancashire.',
         ''
       )
     );

--- a/functions/src/contentExtractors/morningBriefingTopStories.ts
+++ b/functions/src/contentExtractors/morningBriefingTopStories.ts
@@ -15,7 +15,7 @@ This data is extracted from the HTML of the morning briefing article.
 Ignore the midweek catchup
 */
 
-const numberOfStoriesNeeded = 3;
+const numberOfStoriesNeeded = 4;
 
 const extractArticles = (
   articleParagraphs: string[],
@@ -125,7 +125,7 @@ const getTopStoriesFromMorningBriefing = (
   const articleParagraphs = getTextBlocksFromArticle(result);
   const articles = extractArticles(articleParagraphs, articleSource);
   if (articles.length === numberOfStoriesNeeded) {
-    return new TopStories(articles[0], articles[1], articles[2]);
+    return new TopStories(articles[0], articles[1], articles[2], articles[3]);
   } else {
     console.error(
       `Could not build TopStories object for ${JSON.stringify(articles)}`

--- a/functions/src/generators/nastySSMLGeneration/weekdayAMSSMLGeneration.ts
+++ b/functions/src/generators/nastySSMLGeneration/weekdayAMSSMLGeneration.ts
@@ -15,15 +15,15 @@ const generateWeekdayAMSSML = (weekdayAMBriefing: WeekdayAMBriefing) => {
     weekdayAMBriefing.todayInFocus,
     'wordsHD3'
   );
-  const trendingArticleSSML = generateTrendingArticle(
-    weekdayAMBriefing.trendingArticle,
+  const finalArticle = generateFinalArticle(
+    weekdayAMBriefing.topStories.story4,
     'wordsTIF'
   );
-  const outro = generateOutro('wordsTrending');
+  const outro = generateOutro('wordsFinalArticle');
   return weekdayAMBriefingSSML(
     topStoriesSSML,
     todayInFocusSSML,
-    trendingArticleSSML,
+    finalArticle,
     outro
   );
 };
@@ -31,7 +31,7 @@ const generateWeekdayAMSSML = (weekdayAMBriefing: WeekdayAMBriefing) => {
 const weekdayAMBriefingSSML = (
   topStoriesSSML: string,
   todayInFocusSSML: string,
-  trendingArticleSSML: string,
+  finalArticle: string,
   outro: string
 ) => {
   const ssml = `
@@ -49,7 +49,7 @@ const weekdayAMBriefingSSML = (
 
       ${topStoriesSSML}
       ${todayInFocusSSML}
-      ${trendingArticleSSML}
+      ${finalArticle}
       ${outro}
     </par> 
   </speak>`;
@@ -85,7 +85,7 @@ const generateTopStories = (stories: TopStories) => {
     </media>
 
     <media xml:id='HL3' begin='wordsHL2.end-0.0s'>
-      <audio src='https://storage.googleapis.com/gu-briefing-audio-assets/HL3.ogg'/>
+      <audio src='https://storage.googleapis.com/gu-briefing-audio-assets/Morning_Briefing_UK_HL3.ogg'/>
     </media>
 
     <media xml:id='wordsHD3' begin='HL3.end-0.0s' soundLevel='-1dB'>
@@ -130,13 +130,13 @@ const generateTodayInFocusStandfirst = (standfirst: string) => {
     }, '');
 };
 
-const generateTrendingArticle = (article: Article, previous: string) => {
+const generateFinalArticle = (article: Article, previous: string) => {
   const ssml = `
-    <media xml:id='trending' begin='${previous}.end+0.4s'>
-      <audio src='https://storage.googleapis.com/gu-briefing-audio-assets/Trend.ogg'/>
+    <media xml:id='FinalArticle' begin='${previous}.end+0.4s'>
+      <audio src='https://storage.googleapis.com/gu-briefing-audio-assets/Morning_Briefing_HL4.ogg'/>
     </media>
 
-    <media xml:id='wordsTrending' begin='trending.end+0.0s' soundLevel='-1dB'>
+    <media xml:id='wordsFinalArticle' begin='FinalArticle.end+0.0s' soundLevel='-1dB'>
       <speak>
       ${encodeStringForSSML(article.standfirst)}
       </speak>

--- a/functions/src/models/contentModels.ts
+++ b/functions/src/models/contentModels.ts
@@ -27,7 +27,8 @@ class TopStories extends OptionContent {
   constructor(
     public story1: Article,
     public story2: Article,
-    public story3: Article
+    public story3: Article,
+    public story4: Article
   ) {
     super();
   }
@@ -57,11 +58,7 @@ class CapiTopArticles extends OptionContent {
 }
 
 class WeekdayAMBriefing {
-  constructor(
-    public topStories: TopStories,
-    public todayInFocus: Article,
-    public trendingArticle: Article
-  ) {}
+  constructor(public topStories: TopStories, public todayInFocus: Article) {}
 }
 
 class FallbackBriefing {


### PR DESCRIPTION
The trending article included in the Weekday AM briefing was often covering a topic already covered in the headlines pulled from the morning briefing article. Switch to pulling all 4 headlines in the Weekday AM briefing from the morning briefing article published weekday mornings.