### PR TITLE
Use outro that doesn't mention days of the week.

### DIFF
--- a/functions/src/generators/nastySSMLGeneration/weekdayAMSSMLGeneration.ts
+++ b/functions/src/generators/nastySSMLGeneration/weekdayAMSSMLGeneration.ts
@@ -147,7 +147,7 @@ const generateFinalArticle = (article: Article, previous: string) => {
 const generateOutro = (previous: string) => {
   const ssml = `
     <media xml:id='outro' begin='${previous}.end+0.0s'>
-      <audio src='https://storage.googleapis.com/gu-briefing-audio-assets/Outro.ogg'/>
+      <audio src='https://storage.googleapis.com/gu-briefing-audio-assets/MorningBriefingOutro.ogg'/>
     </media>
 
     <media xml:id='music1' begin='advert.end-0.3s' soundLevel='-1.0dB'>


### PR DESCRIPTION
The AM weekday briefing was referencing "come back every weekday" rather than come back any time.